### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: SonarQube
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/vepo/morpho-board/security/code-scanning/1](https://github.com/vepo/morpho-board/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's tasks, it likely only needs read access to the repository contents. If additional permissions are required (e.g., for pull requests), they can be added explicitly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build`) to limit permissions for that job only. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
